### PR TITLE
(#100) Added PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,38 @@
+# Bugfix: <short description>
+
+---
+
+## 🪳 Bug Description
+<!-- What was broken? -->
+
+---
+
+## 🔁 Steps to Reproduce
+1.
+2.
+3.
+
+---
+
+## ✅ Fix Summary
+<!-- What was changed to fix it? -->
+
+---
+
+## 🔧 Changes
+
+### Fix
+
+-
+
+<!-- Optional sections
+
+---
+
+## 📝 Technical Notes
+
+
+---
+
+## Other related sections
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,40 @@
+# Feature: <short description>
+
+---
+
+## 🎥 Demo
+**Demo video**
+
+<!-- Drag & drop video here or paste link -->
+
+_(what is shown in the video    )_
+
+---
+
+## 📌 Summary
+<!-- What does this PR do and why? -->
+
+---
+
+## 🔧 Changes
+
+### Feature 1
+
+-
+
+### Feature 2
+
+- 
+
+
+<!-- Optional sections
+
+---
+
+## 📝 Technical Notes
+
+
+---
+
+## Other related sections
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/task.md
+++ b/.github/PULL_REQUEST_TEMPLATE/task.md
@@ -1,0 +1,40 @@
+# Task: <short description>
+
+---
+
+## 📌 Objective
+<!-- What is the goal of this task? -->
+
+---
+
+## 🧠 Context
+<!-- Why is this needed? -->
+
+---
+
+## 🔧 Changes
+
+### Work Done
+
+-
+
+---
+
+## ✅ Outcome
+<!-- What is improved after this PR? -->
+
+-
+
+<!-- Optional sections
+
+---
+
+
+## 📝 Technical Notes
+Optional implementation details
+
+
+---
+
+## Other related sections
+-->


### PR DESCRIPTION
# Task: Add PR template

---

## 📌 Objective
Add PR templates for future PRs

---

## 🧠 Context
Following our [Retrospective 2](https://www.reetro.app/board/69792c5e6d7e4076342de898/69846c6d7684dc7d94f97c28), a valid concern that was brought up was the lack of homogeneity in our Pull Requests, as well as the lack of details. Hence, to make it similar for each and everyone of us, added the template used to make [PR #91](https://github.com/SOEN390-ConUNav/SOEN390-Mini-Cap-Project/pull/91)

---

## 🔧 Changes

### .Github/ 

- Added `PULL_REQUEST_TEMPLATE/`
- Added `PULL_REQUEST_TEMPLATE/bugfix.md`
- Added `PULL_REQUEST_TEMPLATE/feature.md`
- Added `PULL_REQUEST_TEMPLATE/task.md`

---

## ✅ Outcome

- After the merging of this PR onto main, creating pull requests should trigger a template picker so that devs will be able to select a specific PR template that will autofill the layout of the description's markdown as such:
<img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/74a94c1a-c95a-4a93-b985-962ebb1a57e7" />


---

## 📝 Technical Notes

- Based on the folder name, github should be aware of the existence of templates